### PR TITLE
Update scrt_interface.py

### DIFF
--- a/TNLS-Relayers/scrt_interface.py
+++ b/TNLS-Relayers/scrt_interface.py
@@ -40,6 +40,7 @@ class SCRTInterface(BaseChainInterface):
         self.wallet = self.provider.wallet(self.private_key)
         self.api_url = api_url
         self.logger = getLogger()
+        self.logger.setLevel(INFO)
 
         # Initialize account number and sequence
         self.account_number = None


### PR DESCRIPTION
logs at info level are not shown without this. so if someone starts their own custom relayer, by default the logs are currently at warning level, but i think they should be at info log level.

for example, without this change, if the relayer tries to broadcast a transaction, then it won't output the following because it is an info level log `[INFO] Transaction broadcasted with hash: X`, but it will output `[WARNING] Transaction X not included in a block after 20 retries. Retrying broadcast... (2/3)` since that has log level of warning.